### PR TITLE
fix(app,ci): repare tests with apostrophe

### DIFF
--- a/resources/views/administrator/users/leads/index.blade.php
+++ b/resources/views/administrator/users/leads/index.blade.php
@@ -46,10 +46,10 @@
                                     <td class="align-middle text-center">
                                         @if ($lead['user']['is_user'])
                                         <a href="{{ route('administrator.users.show', ['id' => $lead['user']['identifier']]) }}">
-                                            {{ $lead['civility_name'] }}
+                                            {!! $lead['civility_name'] !!}
                                         </a>
                                         @else
-                                        {{ $lead['civility_name'] }}
+                                        {!! $lead['civility_name'] !!}
                                         @endif
                                     </td>
                                     <td class="align-middle text-center">{{ $lead['email'] }}</td>

--- a/tests/Feature/Http/Controllers/Administrator/Users/LeadsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Administrator/Users/LeadsControllerTest.php
@@ -28,10 +28,10 @@ class LeadsControllerTest extends TestCase
             ->assertSeeText('Leads')
             ->assertSeeText('Transform into a user')
             ->assertSeeText($leads->last()->email)
-            ->assertSeeText(htmlentities($leads->last()->civility_name))
+            ->assertSeeText($leads->last()->civility_name)
             ->assertSeeText($leads->last()->identifier)
             ->assertDontSeeText($leads->first()->email)
-            ->assertDontSeeText(htmlentities($leads->first()->civility_name))
+            ->assertDontSeeText($leads->first()->civility_name)
             ->assertDontSeeText($leads->first()->identifier)
             ->assertSuccessful();
     }
@@ -55,7 +55,31 @@ class LeadsControllerTest extends TestCase
             ->assertSeeText('Aucune action')
             ->assertSeeInOrder(['<tr id="lead_1">', '<i class="far fa-user-circle" title="Transformed user"></i>'])
             ->assertSeeText($lead->email)
-            ->assertSeeText(htmlentities($lead->civility_name))
+            ->assertSeeText($lead->civility_name)
+            ->assertSeeText($lead->identifier)
+            ->assertSuccessful();
+    }
+
+    public function testUpdateWithApostrophe()
+    {
+        $this->actingAsAdministrator();
+        $lead = factory(Lead::class)->create(['last_name' => "D'amore"]);
+        Notification::fake();
+        $this
+            ->assertAuthenticated()
+            ->put("/administrator/users/leads/{$lead->id}")
+            ->assertStatus(302)
+            ->assertRedirect('administrator/users/leads');
+        $lead->refresh();
+        Notification::assertSentTo($lead->user, CreatedAccountByAdministrator::class);
+
+        $this
+            ->assertAuthenticated()
+            ->get('/administrator/users/leads')
+            ->assertSeeText('Aucune action')
+            ->assertSeeInOrder(['<tr id="lead_1">', '<i class="far fa-user-circle" title="Transformed user"></i>'])
+            ->assertSeeText($lead->email)
+            ->assertSeeText($lead->civility_name)
             ->assertSeeText($lead->identifier)
             ->assertSuccessful();
     }

--- a/tests/Feature/Http/Controllers/Administrator/Users/LeadsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Administrator/Users/LeadsControllerTest.php
@@ -28,10 +28,10 @@ class LeadsControllerTest extends TestCase
             ->assertSeeText('Leads')
             ->assertSeeText('Transform into a user')
             ->assertSeeText($leads->last()->email)
-            ->assertSeeText($leads->last()->civility_name)
+            ->assertSeeText(htmlentities($leads->last()->civility_name))
             ->assertSeeText($leads->last()->identifier)
             ->assertDontSeeText($leads->first()->email)
-            ->assertDontSeeText($leads->first()->civility_name)
+            ->assertDontSeeText(htmlentities($leads->first()->civility_name))
             ->assertDontSeeText($leads->first()->identifier)
             ->assertSuccessful();
     }
@@ -43,7 +43,7 @@ class LeadsControllerTest extends TestCase
         Notification::fake();
         $this
             ->assertAuthenticated()
-            ->put('/administrator/users/leads/'.$lead->id)
+            ->put("/administrator/users/leads/{$lead->id}")
             ->assertStatus(302)
             ->assertRedirect('administrator/users/leads');
         $lead->refresh();
@@ -55,7 +55,7 @@ class LeadsControllerTest extends TestCase
             ->assertSeeText('Aucune action')
             ->assertSeeInOrder(['<tr id="lead_1">', '<i class="far fa-user-circle" title="Transformed user"></i>'])
             ->assertSeeText($lead->email)
-            ->assertSeeText($lead->civility_name)
+            ->assertSeeText(htmlentities($lead->civility_name))
             ->assertSeeText($lead->identifier)
             ->assertSuccessful();
     }


### PR DESCRIPTION
| Q | A |
| :--- | :---: |
| Issue ? | N/A |
| Depends on pull requests ? | No |
| Embeds pull requests ? | No |
| Is it automatically tested ? | Yes |
| Contains unit tests ? | No |
| Contains functional tests ? | Yes |
| Contains acceptance tests ? | No |

## How to test it manually

- tests like `Monsieur D'amore Makenna` pass CI in `Tests\Feature\Http\Controllers\Administrator\Users\LeadsControllerTest::testUpdate`