### PR TITLE
fix(test): rollback the use of faker imgurl method to the use of resource test image

### DIFF
--- a/tests/Feature/Http/Controllers/Anonymous/Files/FilesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Anonymous/Files/FilesControllerTest.php
@@ -18,7 +18,7 @@ class FilesControllerTest extends TestCase
     public function testToGetDocument()
     {
         $cloudFilePath = 'file001.jpg';
-        $cloudFileContent = file_get_contents($this->faker->imageUrl());
+        $cloudFileContent = file_get_contents(base_path('resources/images/test.jpg'));
 
         Storage::fake('object-storage');
         Storage::cloud()->put($cloudFilePath, $cloudFileContent);
@@ -37,7 +37,7 @@ class FilesControllerTest extends TestCase
     public function testToGetThumbnail()
     {
         $cloudFilePath = 'file002.jpg';
-        $cloudFileContent = file_get_contents($this->faker->imageUrl());
+        $cloudFileContent = file_get_contents(base_path('resources/images/test.jpg'));
 
         Storage::fake('object-storage');
         Storage::fake('thumbnails');

--- a/tests/Feature/Http/Controllers/Anonymous/Files/MediasControllerTest.php
+++ b/tests/Feature/Http/Controllers/Anonymous/Files/MediasControllerTest.php
@@ -33,7 +33,7 @@ class MediasControllerTest extends TestCase
         ]);
 
         $cloudFilePath = "{$media->id}/file001.jpg";
-        $cloudFileContent = file_get_contents($this->faker->imageUrl());
+        $cloudFileContent = file_get_contents(base_path('resources/images/test.jpg'));
 
         Storage::fake('object-storage');
         Storage::cloud()->put($cloudFilePath, $cloudFileContent);


### PR DESCRIPTION
| Q | A |
| :--- | :---: |
| Contains unit tests ? | No |
| Contains functional tests ? | Yes |
| Contains acceptance tests ? | No |

## How to test it manually

`phpunit` should success