### PR TITLE
feat(app): remove queue:work & crawler:pokemongofriendcodes from schedule

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -50,20 +50,8 @@ class Kernel extends ConsoleKernel
             ->everyFiveMinutes()
             ->withoutOverlapping();
         $schedule
-            ->command('queue:work', [
-                env('QUEUE_CONNECTION'),
-                '--stop-when-empty',
-                '--queue' => 'high,default,low',
-            ])
-            ->everyMinute()
-            ->withoutOverlapping();
-        $schedule
             ->command('pkmn:daily-sponsor')
             ->daily()
-            ->withoutOverlapping();
-        $schedule
-            ->command('crawler:pokemongofriendcodes')
-            ->monthly()
             ->withoutOverlapping();
     }
 


### PR DESCRIPTION
| Q | A |
| :--- | :---: |
| Contains unit tests ? | No |
| Contains functional tests ? | No |

## How to test it manually

schedule does not execute  queue:work & crawler:pokemongofriendcodes anymore.